### PR TITLE
use standard versioning major.minor.bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Or on a YARN cluster:
 # Building
 
 
-To retrieve the latest development version (0.3-SNAPSHOT) of the Cascading Connector for Apache Flink, run the following command
+To retrieve the latest development version (0.3.0-SNAPSHOT) of the Cascading Connector for Apache Flink, run the following command
 
     git clone https://github.com/dataArtisans/cascading-flink.git
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
 	<groupId>com.data-artisans</groupId>
 	<artifactId>cascading-flink</artifactId>
-	<version>0.3-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 
 	<name>Cascading on Flink</name>
 	<packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@ limitations under the License.
 
 	<properties>
 		<!-- dependency versions -->
-		<cascading.version>3.1.0-wip-56</cascading.version>
-		<flink.version>1.0.1</flink.version>
+		<cascading.version>3.1.0-wip-60</cascading.version>
+		<flink.version>1.0.3</flink.version>
 		<slf4j.version>1.7.7</slf4j.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,14 @@ limitations under the License.
 	</profiles>
 
 	<build>
+
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/dataartisans/flink/cascading/planner/FlinkPlanner.java
+++ b/src/main/java/com/dataartisans/flink/cascading/planner/FlinkPlanner.java
@@ -79,7 +79,7 @@ public class FlinkPlanner extends FlowPlanner<FlinkFlow, Configuration> {
 
 	@Override
 	public PlatformInfo getPlatformInfo() {
-		return new PlatformInfo("Apache Flink", "data Artisans GmbH", "0.1");
+		return new PlatformInfo("Apache Flink", "data Artisans GmbH", "${project.version}");
 	}
 
 	@Override


### PR DESCRIPTION
The project should use standard versioning practice and publish jars that follow the major.minor.bugfix schema.