### PR TITLE
use Flink 1.0.3 and Cascading 3.1.0-wip-60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@ limitations under the License.
 
 	<properties>
 		<!-- dependency versions -->
-		<cascading.version>3.1.0-wip-56</cascading.version>
-		<flink.version>1.0.1</flink.version>
+		<cascading.version>3.1.0-wip-60</cascading.version>
+		<flink.version>1.0.3</flink.version>
 		<slf4j.version>1.7.7</slf4j.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Cascading 3.1.0-wip-60 is most likely the one that is going to be the release. This updates the project to use that version.