### PR TITLE
set the platform version automatically during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,14 @@ limitations under the License.
 	</profiles>
 
 	<build>
+
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/dataartisans/flink/cascading/planner/FlinkPlanner.java
+++ b/src/main/java/com/dataartisans/flink/cascading/planner/FlinkPlanner.java
@@ -28,6 +28,7 @@ import cascading.flow.planner.process.FlowNodeGraph;
 import cascading.flow.planner.process.FlowStepFactory;
 import cascading.flow.planner.rule.RuleRegistry;
 import cascading.tap.Tap;
+import com.dataartisans.flink.cascading.util.Version;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.client.CliFrontend;
 import org.apache.flink.configuration.ConfigConstants;
@@ -79,7 +80,7 @@ public class FlinkPlanner extends FlowPlanner<FlinkFlow, Configuration> {
 
 	@Override
 	public PlatformInfo getPlatformInfo() {
-		return new PlatformInfo("Apache Flink", "data Artisans GmbH", "0.1");
+		return Version.getPlatformInfo();
 	}
 
 	@Override

--- a/src/main/java/com/dataartisans/flink/cascading/util/Version.java
+++ b/src/main/java/com/dataartisans/flink/cascading/util/Version.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 data Artisans GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dataartisans.flink.cascading.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import cascading.flow.planner.PlatformInfo;
+
+/**
+ * Util class for version related information.
+ */
+public class Version{
+
+	private static final String PROPERTIES_FILE = "cascading/flink/version.properties";
+
+	private static Properties properties;
+
+	static {
+			try {
+				properties = loadVersionProperties();
+			}
+			catch(IOException exception){
+				// ignore
+			}
+		}
+
+	public static String getPlatformVersion(){
+		return properties.getProperty("platform.version");
+	}
+
+	public static String getPlatformName(){
+		return properties.getProperty("platform.name");
+	}
+
+	public static String getPlatformVendor(){
+		return properties.getProperty("platform.vendor");
+	}
+
+	public static PlatformInfo getPlatformInfo(){
+		return new PlatformInfo(getPlatformName(), getPlatformVendor(), getPlatformVersion());
+	}
+
+	public static Properties loadVersionProperties() throws IOException {
+		Properties properties = new Properties();
+		InputStream stream = Version.class.getClassLoader().getResourceAsStream(PROPERTIES_FILE);
+		if(stream == null){
+			return properties;
+		}
+		try{
+			properties.load(stream);
+		}
+	finally{
+		stream.close();
+	}
+	return properties;
+	}
+
+}

--- a/src/main/resources/cascading/flink/version.properties
+++ b/src/main/resources/cascading/flink/version.properties
@@ -1,0 +1,3 @@
+platform.vendor=data Artisans GmbH
+platform.name=Apache Flink
+platform.version=${project.version}


### PR DESCRIPTION
The platform version shows up in driven, so it is a good idea to have it correct. This PR uses maven resource filtering, to make sure it is always up2date.