### PR TITLE
Upgrade to Flink 1.18, fix test failures, runs on YARN cluster against hadoop 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Or on a YARN cluster:
 # Building
 
 
-To retrieve the latest development version (0.4.0-SNAPSHOT) of the Cascading Connector for Apache Flink™, run the following command
+To retrieve the latest development version (0.4.1-SNAPSHOT) of the Cascading Connector for Apache Flink™, run the following command
 
     git clone https://github.com/dataArtisans/cascading-flink.git
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
 	<groupId>com.data-artisans</groupId>
 	<artifactId>cascading-flink</artifactId>
-	<version>0.4.0-SNAPSHOT</version>
+	<version>0.4.1-SNAPSHOT</version>
 
 	<name>Cascading on Flink</name>
 	<packaging>jar</packaging>
@@ -52,9 +52,11 @@ limitations under the License.
 
 	<properties>
 		<!-- dependency versions -->
-		<cascading.version>3.1.0</cascading.version>
-		<flink.version>1.0.3</flink.version>
-		<slf4j.version>1.7.7</slf4j.version>
+		<cascading.version>3.1.2</cascading.version>
+		<flink.version>1.18.1</flink.version>
+		<slf4j.version>1.7.32</slf4j.version>
+		<log4j.version>2.17.1</log4j.version>
+		<hadoop.version>2.10.0</hadoop.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -68,27 +70,21 @@ limitations under the License.
 	</properties>
 
 	<repositories>
-
+	        <repository>
+	            <id>conjars.org</id>
+	            <url>https://conjars.wensel.net/repo</url>
+	        </repository>
 		<repository>
-			<id>conjars.org</id>
-			<url>https://conjars.org/repo</url>
-		</repository>
-
-		<!--
-		<repository>
-			<id>flink.release-staging</id>
-			<name>Apache Development Snapshot Repository</name>
-			<url>https://repository.apache.org/content/repositories/orgapacheflink-1063</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
+			<id>repository.jboss.org</id>
+			<url>http://repository.jboss.org/nexus/content/groups/public/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
 		</repository>
-		-->
-
-	</repositories>
+    	</repositories>
 
 	<distributionManagement>
 		<snapshotRepository>
@@ -107,13 +103,19 @@ limitations under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_2.10</artifactId>
+			<artifactId>flink-clients</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
+			<version>${flink.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hadoop-compatibility_2.12</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 
@@ -129,12 +131,32 @@ limitations under the License.
 			<groupId>cascading</groupId>
 			<artifactId>cascading-hadoop2-io</artifactId>
 			<version>${cascading.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
 			<groupId>cascading</groupId>
 			<artifactId>cascading-expression</artifactId>
 			<version>${cascading.version}</version>
+		</dependency>
+
+		<!-- Hadoop -->
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+			<version>${hadoop.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-mapreduce-client-core</artifactId>
+			<version>${hadoop.version}</version>
 		</dependency>
 
 		<!-- CASCADING TESTS -->
@@ -164,11 +186,13 @@ limitations under the License.
 		</dependency>
 
 		<!-- OTHER LIBRARIES -->
+		<!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-core -->
+
 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-hdfs</artifactId>
-			<version>2.2.0</version>
+			<version>${hadoop.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -186,15 +210,27 @@ limitations under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.clapper</groupId>
-			<artifactId>grizzled-slf4j_2.10</artifactId>
-			<version>1.0.2</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
+			<version>${log4j.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.clapper</groupId>
+			<artifactId>grizzled-slf4j_2.10</artifactId>
+			<version>1.3.4</version>
 		</dependency>
 
 		<dependency>
@@ -291,6 +327,31 @@ limitations under the License.
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.4.1</version> <!-- Use the latest version -->
+				<configuration>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<!-- The main class to execute when running the JAR -->
+							<transformers>
+								<transformer
+										implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>com.dataartisans.flink.cascading.example.WordCount</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<version>2.2.1</version>
 				<!--$NO-MVN-MAN-VER$-->
@@ -363,7 +424,8 @@ limitations under the License.
 							distributed under the License is distributed on an "AS IS" BASIS,
 							WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 							See the License for the specific language governing permissions and
-							limitations under the License.
+							limitations under the License.mvn exec:exec -Dinput=kinglear.txt -Doutput=wordcounts.txt
+
 						-->
 						<license
 								implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
@@ -407,33 +469,14 @@ limitations under the License.
 			</plugin>
 
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.12.1</version>
-				<executions>
-					<execution>
-						<id>validate</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<configLocation>/tools/maven/checkstyle.xml</configLocation>
-					<logViolationsToConsole>true</logViolationsToConsole>
-				</configuration>
-			</plugin>
-
-			<plugin>
 				<!-- just define the Java version to be used for compiling and plugins -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<!--$NO-MVN-MAN-VER$-->
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 

--- a/src/main/java/com/dataartisans/flink/cascading/example/WordCount.java
+++ b/src/main/java/com/dataartisans/flink/cascading/example/WordCount.java
@@ -44,7 +44,6 @@ public class WordCount {
 		RegexSplitGenerator splitter = new RegexSplitGenerator( token, "\\s+" );
 		// only returns "token"
 		Pipe docPipe = new Each( "token", text, splitter, Fields.RESULTS );
-
 		Pipe wcPipe = new Pipe( "wc", docPipe );
 		wcPipe = new AggregateBy( wcPipe, token, new CountBy(new Fields("count")));
 

--- a/src/main/java/com/dataartisans/flink/cascading/planner/FlinkFlow.java
+++ b/src/main/java/com/dataartisans/flink/cascading/planner/FlinkFlow.java
@@ -24,6 +24,7 @@ import cascading.flow.hadoop.util.HadoopUtil;
 import cascading.flow.planner.PlatformInfo;
 import com.dataartisans.flink.cascading.runtime.util.FlinkFlowProcess;
 import org.apache.flink.client.program.OptimizerPlanEnvironment;
+import org.apache.flink.client.program.ProgramAbortException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import riffle.process.ProcessComplete;
@@ -81,8 +82,8 @@ public class FlinkFlow extends BaseFlow<Configuration> {
 		catch(FlowException fe) {
 			// check if we need to unwrap a ProgramAbortException
 			Throwable t = fe.getCause();
-			if (t instanceof OptimizerPlanEnvironment.ProgramAbortException) {
-				throw (OptimizerPlanEnvironment.ProgramAbortException)t;
+			if (t instanceof ProgramAbortException) {
+				throw (ProgramAbortException)t;
 			}
 			else {
 				throw fe;

--- a/src/main/java/com/dataartisans/flink/cascading/planner/FlinkFlowStep.java
+++ b/src/main/java/com/dataartisans/flink/cascading/planner/FlinkFlowStep.java
@@ -49,6 +49,8 @@ import com.dataartisans.flink.cascading.runtime.coGroup.bufferJoin.CoGroupBuffer
 import com.dataartisans.flink.cascading.runtime.coGroup.regularJoin.CoGroupReducer;
 import com.dataartisans.flink.cascading.runtime.coGroup.regularJoin.TupleAppendOuterJoiner;
 import com.dataartisans.flink.cascading.runtime.coGroup.regularJoin.TupleOuterJoiner;
+import com.dataartisans.flink.cascading.runtime.each.EachMapper;
+import com.dataartisans.flink.cascading.runtime.groupBy.GroupByReducer;
 import com.dataartisans.flink.cascading.runtime.groupBy.GroupByReducer;
 import com.dataartisans.flink.cascading.runtime.hashJoin.NaryHashJoinJoiner;
 import com.dataartisans.flink.cascading.runtime.util.FlinkFlowProcess;
@@ -57,9 +59,9 @@ import com.dataartisans.flink.cascading.runtime.hashJoin.JoinPrepareMapper;
 import com.dataartisans.flink.cascading.runtime.hashJoin.TupleAppendCrosser;
 import com.dataartisans.flink.cascading.runtime.hashJoin.TupleAppendJoiner;
 import com.dataartisans.flink.cascading.runtime.hashJoin.HashJoinMapper;
-import com.dataartisans.flink.cascading.runtime.each.EachMapper;
 import com.dataartisans.flink.cascading.runtime.sink.TapOutputFormat;
 import com.dataartisans.flink.cascading.runtime.source.TapInputFormat;
+import com.dataartisans.flink.cascading.runtime.util.FlinkFlowProcess;
 import com.dataartisans.flink.cascading.runtime.util.IdMapper;
 import com.dataartisans.flink.cascading.types.tuple.TupleTypeInfo;
 import com.dataartisans.flink.cascading.types.tuplearray.TupleArrayTypeInfo;
@@ -71,9 +73,9 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.operators.Operator;
 import org.apache.flink.api.java.operators.GroupReduceOperator;
 import org.apache.flink.api.java.operators.JoinOperator;
-import org.apache.flink.api.java.operators.Operator;
 import org.apache.flink.api.java.operators.PartitionOperator;
 import org.apache.flink.api.java.operators.SortPartitionOperator;
 import org.apache.flink.api.java.operators.SortedGrouping;
@@ -102,8 +104,8 @@ public class FlinkFlowStep extends BaseFlowStep<Configuration> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkFlowStep.class);
 
-	private ExecutionEnvironment env;
-	private List<String> classPath;
+	private final ExecutionEnvironment env;
+	private final List<String> classPath;
 
 	public FlinkFlowStep(ExecutionEnvironment env, ElementGraph elementGraph, FlowNodeGraph flowNodeGraph, List<String> classPath) {
 		super(elementGraph, flowNodeGraph);

--- a/src/main/java/com/dataartisans/flink/cascading/planner/FlinkFlowStepJob.java
+++ b/src/main/java/com/dataartisans/flink/cascading/planner/FlinkFlowStepJob.java
@@ -179,7 +179,6 @@ public class FlinkFlowStepJob extends FlowStepJob<Configuration> {
             client.getJobExecutionResult().get(100, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             return false;
-            ExecutionException
         } catch (ExecutionException e) {
             jobException = e.getCause();
             return false;

--- a/src/main/java/com/dataartisans/flink/cascading/planner/FlinkFlowStepStats.java
+++ b/src/main/java/com/dataartisans/flink/cascading/planner/FlinkFlowStepStats.java
@@ -19,8 +19,8 @@ package com.dataartisans.flink.cascading.planner;
 import cascading.flow.FlowStep;
 import cascading.management.state.ClientState;
 import cascading.stats.FlowStepStats;
-import com.dataartisans.flink.cascading.runtime.stats.EnumStringConverter;
 import com.dataartisans.flink.cascading.runtime.stats.AccumulatorCache;
+import com.dataartisans.flink.cascading.runtime.stats.EnumStringConverter;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -29,82 +29,82 @@ import java.util.Set;
 
 public class FlinkFlowStepStats extends FlowStepStats {
 
-	private AccumulatorCache accumulatorCache;
+    private final AccumulatorCache accumulatorCache;
 
-	protected FlinkFlowStepStats(FlowStep flowStep, ClientState clientState, AccumulatorCache accumulatorCache) {
-		super(flowStep, clientState);
-		this.accumulatorCache = accumulatorCache;
-	}
+    protected FlinkFlowStepStats(FlowStep flowStep, ClientState clientState, AccumulatorCache accumulatorCache) {
+        super(flowStep, clientState);
+        this.accumulatorCache = accumulatorCache;
+    }
 
-	@Override
-	public void recordChildStats() {
-		// TODO
-	}
+    @Override
+    public void recordChildStats() {
+        // TODO
+    }
 
-	@Override
-	public String getProcessStepID() {
-		return null;
-	}
+    @Override
+    public String getProcessStepID() {
+        return null;
+    }
 
-	@Override
-	public Collection<String> getCounterGroupsMatching(String regex) {
-		return null;
-	}
+    @Override
+    public Collection<String> getCounterGroupsMatching(String regex) {
+        return null;
+    }
 
-	@Override
-	public void captureDetail(Type depth) {
-		// TODO
-	}
+    @Override
+    public void captureDetail(Type depth) {
+        // TODO
+    }
 
-	@Override
-	public long getLastSuccessfulCounterFetchTime() {
-		return accumulatorCache.getLastUpdateTime();
-	}
+    @Override
+    public long getLastSuccessfulCounterFetchTime() {
+        return accumulatorCache.getLastUpdateTime();
+    }
 
-	@Override
-	public Collection<String> getCounterGroups() {
-		accumulatorCache.update();
-		Map<String, Object> currentAccumulators = accumulatorCache.getCurrentAccumulators();
-		Set<String> result = new HashSet<String>();
+    @Override
+    public Collection<String> getCounterGroups() {
+        accumulatorCache.update();
+        Map<String, Object> currentAccumulators = accumulatorCache.getCurrentAccumulators();
+        Set<String> result = new HashSet<String>();
 
-		for (String key : currentAccumulators.keySet()) {
-			result.add(EnumStringConverter.groupCounterToGroup(key));
-		}
-		return result;
-	}
+        for (String key : currentAccumulators.keySet()) {
+            result.add(EnumStringConverter.groupCounterToGroup(key));
+        }
+        return result;
+    }
 
-	@Override
-	public Collection<String> getCountersFor(String group) {
-		accumulatorCache.update();
-		Map<String, Object> currentAccumulators = accumulatorCache.getCurrentAccumulators();
-		Set<String> result = new HashSet<String>();
+    @Override
+    public Collection<String> getCountersFor(String group) {
+        accumulatorCache.update();
+        Map<String, Object> currentAccumulators = accumulatorCache.getCurrentAccumulators();
+        Set<String> result = new HashSet<String>();
 
-		for (String key : currentAccumulators.keySet()) {
-			if (EnumStringConverter.accInGroup(group, key)) {
-				result.add(EnumStringConverter.groupCounterToCounter(key));
-			}
-		}
-		return result;
-	}
+        for (String key : currentAccumulators.keySet()) {
+            if (EnumStringConverter.accInGroup(group, key)) {
+                result.add(EnumStringConverter.groupCounterToCounter(key));
+            }
+        }
+        return result;
+    }
 
-	@Override
-	public long getCounterValue(Enum counter) {
-		return getCounterValue(EnumStringConverter.enumToGroup(counter), EnumStringConverter.enumToCounter(counter));
-	}
+    @Override
+    public long getCounterValue(Enum counter) {
+        return getCounterValue(EnumStringConverter.enumToGroup(counter), EnumStringConverter.enumToCounter(counter));
+    }
 
-	@Override
-	public long getCounterValue(String group, String counter) {
-		accumulatorCache.update();
-		Map<String, Object> currentAccumulators = accumulatorCache.getCurrentAccumulators();
+    @Override
+    public long getCounterValue(String group, String counter) {
+        accumulatorCache.update();
+        Map<String, Object> currentAccumulators = accumulatorCache.getCurrentAccumulators();
 
-		for (String key : currentAccumulators.keySet()) {
-			if (EnumStringConverter.accMatchesGroupCounter(key, group, counter)) {
-				Object o = currentAccumulators.get(key);
-				return (Long) o;
-			}
-		}
-		// Cascading returns 0 in case of empty accumulators
-		return 0;
-	}
+        for (String key : currentAccumulators.keySet()) {
+            if (EnumStringConverter.accMatchesGroupCounter(key, group, counter)) {
+                Object o = currentAccumulators.get(key);
+                return (Long) o;
+            }
+        }
+        // Cascading returns 0 in case of empty accumulators
+        return 0;
+    }
 
 }

--- a/src/main/java/com/dataartisans/flink/cascading/planner/FlinkPlanner.java
+++ b/src/main/java/com/dataartisans/flink/cascading/planner/FlinkPlanner.java
@@ -30,7 +30,7 @@ import cascading.flow.planner.rule.RuleRegistry;
 import cascading.tap.Tap;
 import com.dataartisans.flink.cascading.util.Version;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.client.CliFrontend;
+import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.hadoop.conf.Configuration;
@@ -45,19 +45,18 @@ public class FlinkPlanner extends FlowPlanner<FlinkFlow, Configuration> {
 
 	private Configuration defaultConfig;
 
-	private List<String> classPath;
+	private final List<String> classPath;
 
-	private ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+	private final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
 	public FlinkPlanner(List<String> classPath) {
 		super();
 		this.classPath = classPath;
 
-		env.getConfig().disableSysoutLogging();
 		if (env.getParallelism() <= 0) {
 			// load the default parallelism from config
 			GlobalConfiguration.loadConfiguration(new File(CliFrontend.getConfigurationDirectoryFromEnv()).getAbsolutePath());
-			org.apache.flink.configuration.Configuration configuration = GlobalConfiguration.getConfiguration();
+			org.apache.flink.configuration.Configuration configuration = GlobalConfiguration.loadConfiguration();
 			int parallelism = configuration.getInteger(ConfigConstants.DEFAULT_PARALLELISM_KEY, -1);
 			if (parallelism <= 0) {
 				throw new RuntimeException("Please set the default parallelism via the -p command-line flag");

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/boundaryStages/BoundaryInStage.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/boundaryStages/BoundaryInStage.java
@@ -64,8 +64,8 @@ public class BoundaryInStage extends ElementStage<Void, TupleEntry> implements I
 			{
 				tuple = tupleIterator.next();
 				tupleEntry.setTuple(tuple);
-				flowProcess.increment( StepCounters.Tuples_Read, 1 );
-				flowProcess.increment( SliceCounters.Tuples_Read, 1 );
+				//flowProcess.increment( StepCounters.Tuples_Read, 1 );
+				//flowProcess.increment( SliceCounters.Tuples_Read, 1 );
 			}
 			catch( OutOfMemoryError error ) {
 				handleReThrowableException( "out of memory, try increasing task memory allocation", error );

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/bufferJoin/BufferJoinKeyExtractor.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/bufferJoin/BufferJoinKeyExtractor.java
@@ -22,9 +22,9 @@ import org.apache.flink.api.java.tuple.Tuple3;
 
 public class BufferJoinKeyExtractor implements MapFunction<Tuple, Tuple3<Tuple, Integer, Tuple>> {
 
-	private int[] keyPos;
-	private Tuple3<Tuple, Integer, Tuple> outT;
-	private Tuple defaultKey = new Tuple(1);
+	private final int[] keyPos;
+	private final Tuple3<Tuple, Integer, Tuple> outT;
+	private final Tuple defaultKey = new Tuple(1);
 
 	public BufferJoinKeyExtractor(int inputId, int[] keyPos) {
 		this.keyPos = keyPos;

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/bufferJoin/CoGroupBufferClosure.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/bufferJoin/CoGroupBufferClosure.java
@@ -143,7 +143,7 @@ public class CoGroupBufferClosure extends JoinerClosure {
 
 		return new TupleBuilder()
 		{
-			Tuple result = TupleViews.createComposite(fields);
+			final Tuple result = TupleViews.createComposite(fields);
 
 			@Override
 			public Tuple makeResult( Tuple[] tuples )
@@ -158,7 +158,7 @@ public class CoGroupBufferClosure extends JoinerClosure {
 		return new Iterator<Tuple>()
 		{
 			final int cleanPos = valueFields.length == 1 ? 0 : pos; // support repeated pipes
-			cascading.tuple.util.TupleBuilder[] valueBuilder = new cascading.tuple.util.TupleBuilder[ valueFields.length ];
+			final cascading.tuple.util.TupleBuilder[] valueBuilder = new cascading.tuple.util.TupleBuilder[ valueFields.length ];
 
 			{
 				for( int i = 0; i < valueFields.length; i++ ) {
@@ -184,7 +184,7 @@ public class CoGroupBufferClosure extends JoinerClosure {
 				else {
 
 					return new cascading.tuple.util.TupleBuilder() {
-						Tuple result = TupleViews.createOverride(valueField, joinField);
+						final Tuple result = TupleViews.createOverride(valueField, joinField);
 
 						@Override
 						public Tuple makeResult(Tuple valueTuple, Tuple groupTuple) {
@@ -291,13 +291,13 @@ public class CoGroupBufferClosure extends JoinerClosure {
 		};
 	}
 
-	static interface TupleBuilder {
+	interface TupleBuilder {
 		Tuple makeResult(Tuple[] tuples);
 	}
 
 	private static class FlinkUnwrappingIterator<F1, F2> implements Iterator<Tuple> {
 
-		private Iterator<Tuple3<F1, F2, Tuple>> flinkIterator;
+		private final Iterator<Tuple3<F1, F2, Tuple>> flinkIterator;
 
 
 		public FlinkUnwrappingIterator(Iterable<Tuple3<F1, F2, Tuple>> vals) {
@@ -359,7 +359,7 @@ public class CoGroupBufferClosure extends JoinerClosure {
 			try {
 				if (iterator == null) {
 					// use emptyList() iterator for java 6 compatibility
-					return Collections.<Tuple>emptyList().iterator();
+					return Collections.emptyIterator();
 				}
 
 				return iterator;

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/regularJoin/CoGroupInGate.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/regularJoin/CoGroupInGate.java
@@ -133,8 +133,8 @@ public class CoGroupInGate extends GroupingSpliceGate implements InputSource {
 
 		private Iterator<Tuple2<Tuple, Tuple[]>> input;
 
-		private JoinClosure closure;
-		private Joiner joiner;
+		private final JoinClosure closure;
+		private final Joiner joiner;
 
 		private Iterator<Tuple> joinedTuples;
 

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/regularJoin/TupleAppendOuterJoiner.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/regularJoin/TupleAppendOuterJoiner.java
@@ -24,10 +24,10 @@ import org.apache.flink.configuration.Configuration;
 
 public class TupleAppendOuterJoiner extends RichJoinFunction<Tuple2<Tuple, Tuple[]>, Tuple, Tuple2<Tuple, Tuple[]>> {
 
-	private int tupleListPos;
-	private int tupleListSize;
-	private Fields inputFields;
-	private Fields keyFields;
+	private final int tupleListPos;
+	private final int tupleListSize;
+	private final Fields inputFields;
+	private final Fields keyFields;
 
 	private transient Tuple2<Tuple, Tuple[]> outT;
 

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/regularJoin/TupleOuterJoiner.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/coGroup/regularJoin/TupleOuterJoiner.java
@@ -24,11 +24,11 @@ import org.apache.flink.configuration.Configuration;
 
 public class TupleOuterJoiner extends RichJoinFunction<Tuple, Tuple, Tuple2<Tuple, Tuple[]>> {
 
-	private int tupleListSize;
-	private Fields inputFieldsLeft;
-	private Fields keyFieldsLeft;
-	private Fields inputFieldsRight;
-	private Fields keyFieldsRight;
+	private final int tupleListSize;
+	private final Fields inputFieldsLeft;
+	private final Fields keyFieldsLeft;
+	private final Fields inputFieldsRight;
+	private final Fields keyFieldsRight;
 
 	private transient Tuple2<Tuple, Tuple[]> outT;
 

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/JoinBoundaryInStage.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/JoinBoundaryInStage.java
@@ -62,8 +62,8 @@ public class JoinBoundaryInStage extends ElementStage<Void, Tuple2<Tuple, Tuple[
 			throw new RuntimeException("JoinBoundaryInStage expects Tuple2<Tuple, Tuple[]>", cce);
 		}
 
-		flowProcess.increment( StepCounters.Tuples_Read, 1 );
-		flowProcess.increment( SliceCounters.Tuples_Read, 1 );
+		//flowProcess.increment( StepCounters.Tuples_Read, 1 );
+		//flowProcess.increment( SliceCounters.Tuples_Read, 1 );
 
 		next.receive(this, joinInputTuples);
 	}

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/JoinBoundaryMapperInStage.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/JoinBoundaryMapperInStage.java
@@ -61,8 +61,8 @@ public class JoinBoundaryMapperInStage extends ElementStage<Void, Tuple2<Tuple, 
 
 			try {
 				joinListTuple = joinInputIterator.next();
-				flowProcess.increment( StepCounters.Tuples_Read, 1 );
-				flowProcess.increment( SliceCounters.Tuples_Read, 1 );
+				//flowProcess.increment( StepCounters.Tuples_Read, 1 );
+				//flowProcess.increment( SliceCounters.Tuples_Read, 1 );
 			}
 			catch( CascadingException exception ) {
 				handleException( exception, null );

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/JoinClosure.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/JoinClosure.java
@@ -99,7 +99,7 @@ public class JoinClosure extends JoinerClosure {
 
 		return new TupleBuilder()
 		{
-			Tuple result = TupleViews.createComposite(fields);
+			final Tuple result = TupleViews.createComposite(fields);
 
 			@Override
 			public Tuple makeResult( Tuple[] tuples )

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/TupleAppendCrosser.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/TupleAppendCrosser.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 
 public class TupleAppendCrosser implements CrossFunction<Tuple2<Tuple, Tuple[]>, Tuple, Tuple2<Tuple, Tuple[]>> {
 
-	private int tupleListPos;
+	private final int tupleListPos;
 
 	public TupleAppendCrosser(int tupleListPos) {
 		this.tupleListPos = tupleListPos;

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/TupleAppendJoiner.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/hashJoin/TupleAppendJoiner.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 
 public class TupleAppendJoiner implements JoinFunction<Tuple2<Tuple, Tuple[]>, Tuple, Tuple2<Tuple, Tuple[]>> {
 
-	private int tupleListPos;
+	private final int tupleListPos;
 
 	public TupleAppendJoiner(int tupleListPos) {
 		this.tupleListPos = tupleListPos;

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/sink/SinkBoundaryInStage.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/sink/SinkBoundaryInStage.java
@@ -34,7 +34,7 @@ import cascading.tuple.TupleEntry;
 public class SinkBoundaryInStage extends ElementStage<Void, TupleEntry> implements InputSource {
 
 	private boolean nextStarted;
-	private TupleEntry tupleEntry;
+	private final TupleEntry tupleEntry;
 
 	public SinkBoundaryInStage(FlowProcess flowProcess, FlowElement flowElement, FlowNode node) {
 		super(flowProcess, flowElement);
@@ -69,8 +69,8 @@ public class SinkBoundaryInStage extends ElementStage<Void, TupleEntry> implemen
 		try {
 			Tuple tuple = (Tuple)input;
 			tupleEntry.setTuple(tuple);
-			flowProcess.increment( StepCounters.Tuples_Read, 1 );
-			flowProcess.increment(SliceCounters.Tuples_Read, 1);
+			//flowProcess.increment( StepCounters.Tuples_Read, 1 );
+			//flowProcess.increment(SliceCounters.Tuples_Read, 1);
 		}
 		catch( OutOfMemoryError error ) {
 			handleReThrowableException("out of memory, try increasing task memory allocation", error);

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/sink/TapOutputFormat.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/sink/TapOutputFormat.java
@@ -47,7 +47,7 @@ public class TapOutputFormat extends RichOutputFormat<Tuple> implements Finalize
 
 	private static final Logger LOG = LoggerFactory.getLogger(TapOutputFormat.class);
 
-	private FlowNode flowNode;
+	private final FlowNode flowNode;
 
 	private transient org.apache.hadoop.conf.Configuration config;
 	private transient FlinkFlowProcess flowProcess;

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/source/SourceStreamGraph.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/source/SourceStreamGraph.java
@@ -29,7 +29,7 @@ import cascading.tap.Tap;
 
 public class SourceStreamGraph extends NodeStreamGraph {
 
-	private TapSourceStage sourceStage;
+	private final TapSourceStage sourceStage;
 	private SingleOutBoundaryStage sinkStage;
 
 	public SourceStreamGraph(FlowProcess flowProcess, FlowNode node, Tap tap) {

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/source/TapInputFormat.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/source/TapInputFormat.java
@@ -64,7 +64,7 @@ public class TapInputFormat extends RichInputFormat<Tuple, HadoopInputSplit> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TapInputFormat.class);
 
-	private FlowNode flowNode;
+	private final FlowNode flowNode;
 
 	private transient SourceStreamGraph streamGraph;
 	private transient TapSourceStage sourceStage;

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/source/TapSourceStage.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/source/TapSourceStage.java
@@ -33,7 +33,7 @@ public class TapSourceStage extends SourceStage {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TapSourceStage.class);
 
-	private Tap source;
+	private final Tap source;
 	private TupleEntryIterator iterator;
 
 	public TapSourceStage(FlowProcess flowProcess, Tap tap) {

--- a/src/main/java/com/dataartisans/flink/cascading/runtime/util/FlinkFlowProcess.java
+++ b/src/main/java/com/dataartisans/flink/cascading/runtime/util/FlinkFlowProcess.java
@@ -42,7 +42,7 @@ import java.util.Set;
 public class FlinkFlowProcess extends FlowProcess<Configuration> {
 
 	private transient RuntimeContext runtimeContext;
-	private Configuration conf;
+	private final Configuration conf;
 	private String taskId;
 
 	public FlinkFlowProcess() {

--- a/src/main/java/com/dataartisans/flink/cascading/types/field/CustomFieldComparator.java
+++ b/src/main/java/com/dataartisans/flink/cascading/types/field/CustomFieldComparator.java
@@ -37,7 +37,7 @@ public class CustomFieldComparator extends TypeComparator<Comparable> {
 
 	private final Hasher hasher;
 
-	private TypeSerializer<Comparable> serializer;
+	private final TypeSerializer<Comparable> serializer;
 
 	private transient Comparable ref;
 
@@ -75,12 +75,7 @@ public class CustomFieldComparator extends TypeComparator<Comparable> {
 	}
 
 	public void setReference(Comparable toCompare) {
-		if(toCompare == null) {
-			this.ref = null;
-		}
-		else {
-			this.ref = toCompare;
-		}
+        this.ref = toCompare;
 	}
 
 	public boolean equalToReference(Comparable candidate) {

--- a/src/main/java/com/dataartisans/flink/cascading/types/field/FieldComparator.java
+++ b/src/main/java/com/dataartisans/flink/cascading/types/field/FieldComparator.java
@@ -30,7 +30,7 @@ public class FieldComparator<T extends Comparable<T>> extends TypeComparator<T> 
 
 	private final boolean ascending;
 	private final Class<T> type;
-	private TypeSerializer<T> serializer;
+	private final TypeSerializer<T> serializer;
 
 	private transient T ref;
 
@@ -59,12 +59,7 @@ public class FieldComparator<T extends Comparable<T>> extends TypeComparator<T> 
 		if(t != null && ref != null) {
 			return t.equals(this.ref);
 		}
-		else if(t == null && ref == null) {
-			return true;
-		}
-		else {
-			return false;
-		}
+		else return t == null && ref == null;
 	}
 
 	@Override

--- a/src/main/java/com/dataartisans/flink/cascading/types/field/WrappingFieldComparator.java
+++ b/src/main/java/com/dataartisans/flink/cascading/types/field/WrappingFieldComparator.java
@@ -67,12 +67,7 @@ public class WrappingFieldComparator<T extends Comparable<T>> extends TypeCompar
 		if(t != null && !this.refNull) {
 			return this.wrappedComparator.equalToReference(t);
 		}
-		else if(t == null && this.refNull) {
-			return true;
-		}
-		else {
-			return false;
-		}
+		else return t == null && this.refNull;
 	}
 
 	@Override

--- a/src/main/java/com/dataartisans/flink/cascading/types/tuple/DefinedTupleSerializer.java
+++ b/src/main/java/com/dataartisans/flink/cascading/types/tuple/DefinedTupleSerializer.java
@@ -20,6 +20,7 @@ import cascading.flow.FlowException;
 import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -227,6 +228,10 @@ public class DefinedTupleSerializer extends TypeSerializer<Tuple> {
 	}
 
 	@Override
+	public TypeSerializerSnapshot<Tuple> snapshotConfiguration() {
+		return null;
+	}
+
 	public boolean canEqual(Object obj) {
 		return obj instanceof DefinedTupleSerializer;
 	}

--- a/src/main/java/com/dataartisans/flink/cascading/types/tuple/TupleTypeInfo.java
+++ b/src/main/java/com/dataartisans/flink/cascading/types/tuple/TupleTypeInfo.java
@@ -35,11 +35,11 @@ public class TupleTypeInfo extends CompositeType<Tuple> {
 
 	private final static int NEG_FIELD_POS_OFFSET = Integer.MAX_VALUE / 2;
 
-	private Fields schema;
+	private final Fields schema;
 
 	private final int length;
-	private LinkedHashMap<String, FieldTypeInfo> fieldTypes;
-	private HashMap<String, Integer> fieldIndexes;
+	private final LinkedHashMap<String, FieldTypeInfo> fieldTypes;
+	private final HashMap<String, Integer> fieldIndexes;
 
 	public TupleTypeInfo(Fields schema) {
 		super(Tuple.class);

--- a/src/main/java/com/dataartisans/flink/cascading/types/tuple/UnknownTupleSerializer.java
+++ b/src/main/java/com/dataartisans/flink/cascading/types/tuple/UnknownTupleSerializer.java
@@ -18,6 +18,7 @@ package com.dataartisans.flink.cascading.types.tuple;
 
 import cascading.tuple.Tuple;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -201,7 +202,12 @@ public class UnknownTupleSerializer extends TypeSerializer<Tuple> {
 		return this.fieldSer.hashCode();
 	}
 
+	// TODO: address checkpoint serailization
 	@Override
+	public TypeSerializerSnapshot<Tuple> snapshotConfiguration() {
+		return null;
+	}
+
 	public boolean canEqual(Object obj) {
 		return obj instanceof UnknownTupleSerializer;
 	}

--- a/src/main/java/com/dataartisans/flink/cascading/types/tuplearray/TupleArraySerializer.java
+++ b/src/main/java/com/dataartisans/flink/cascading/types/tuplearray/TupleArraySerializer.java
@@ -19,6 +19,7 @@ package com.dataartisans.flink.cascading.types.tuplearray;
 import cascading.tuple.Tuple;
 import com.dataartisans.flink.cascading.types.tuple.NullMaskSerDeUtils;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -177,6 +178,10 @@ public class TupleArraySerializer extends TypeSerializer<Tuple[]> {
 	}
 
 	@Override
+	public TypeSerializerSnapshot<Tuple[]> snapshotConfiguration() {
+		return null;
+	}
+
 	public boolean canEqual(Object obj) {
 		return obj instanceof TupleArraySerializer;
 	}

--- a/src/main/java/com/dataartisans/flink/cascading/util/FlinkConfigConstants.java
+++ b/src/main/java/com/dataartisans/flink/cascading/util/FlinkConfigConstants.java
@@ -18,8 +18,16 @@ package com.dataartisans.flink.cascading.util;
 
 public class FlinkConfigConstants {
 
-	public static final String EXECUTION_MODE = "flink.executionMode";
-	public static final String EXECUTION_MODE_BATCH = "BATCH";
-	public static final String EXECUTION_MODE_PIPELINED = "PIPELINED";
+    public static final String EXECUTION_MODE = "flink.executionMode";
+    public static final String EXECUTION_MODE_BATCH = "BATCH";
+    public static final String EXECUTION_MODE_PIPELINED = "PIPELINED";
+
+    public static final String PIPELINE_CLASSPATHS = "pipeline.classpaths";
+
+    public static final String LEAK_CLASSLOADER_CHECK = "classloader.check-leaked-classloader";
+
+    public static final String NETWORK_MEMORY_MIN = "taskmanager.memory.network.min";
+
+    public static final String TASKMANAGER_MEMORY_MANAGED_SIZE = "taskmanager.memory.managed.size";
 
 }


### PR DESCRIPTION
For folks having large number of cascading workload to migrate, this PR might be interesting.
 
- upgrade to Flink 1.18 APIs from Flink 1.0.3
- fix test failures, jar loading
- test local mode  and Hadoop 2.10.0 cluster with migration POC workloads.

Thanks,
Chen